### PR TITLE
feat(dim): allow removing diagnostic signs

### DIFF
--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -62,10 +62,15 @@ function util.highlight_word(ns, line, from, to)
   vim.api.nvim_buf_add_highlight(0, ns, string.format("%sDimmed", final), line, from, to)
   if dim.opts.disable_lsp_decorations then
     for _, lsp_ns in pairs(vim.diagnostic.get_namespaces()) do
-      local namespaces_to_clear = { "underline_ns", "virt_text_ns" }
+      local namespaces_to_clear = { "underline_ns", "virt_text_ns", "sign_group" }
       for _, ns_to_clear in ipairs(namespaces_to_clear) do
         if lsp_ns.user_data[ns_to_clear] then
-          vim.api.nvim_buf_clear_namespace(0, lsp_ns.user_data[ns_to_clear], line, line + 1)
+          local id = lsp_ns.user_data[ns_to_clear]
+          if type(id) == "string" then
+            vim.fn.sign_unplace(id, { buffer = vim.api.nvim_get_current_buf() })
+          else
+            vim.api.nvim_buf_clear_namespace(0, id, line, line + 1)
+          end
         end
       end
     end


### PR DESCRIPTION
This PR allows this plugin to also unset signs for unused variables and functions, not just underlines and virtual text. I'm not sure if they were specifically wanted by since any user using this option has opted out of all decorations, this makes the behaviour more consistent. 

For my specific use case, I have set the `linehl` for my diagnostic signs so diagnostic messages look like

<img width="659" alt="image" src="https://user-images.githubusercontent.com/22454918/173627716-3d5cc390-04ed-45b2-bd4e-8c215c64c512.png">

Which under normal circumstance is my preference, but the colours and highlights make seeing the dimming this plugin does pretty hard to read. I don't want to remove it or change its behaviour, I just want all LSP decorations removed and dimming to be the only visible indication of an issue with an unused variable. Hopefully this makes sense and is fine to incorporate.

Alternatively, if there is a desire to keep signs despite removing everything else, which I think there might not have been since the namespace checks don't explicitly try and filter out signs they just happen to not use namespaces. I can add another config option or allow the existing one to take a string like "include_signs" or something 🤷🏿‍♂️ 
