### PR TITLE
Fix tsserver support

### DIFF
--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -122,6 +122,8 @@ function util.get_treesitter_hl(row, col)
   return matches
 end
 
+local diagnostic_util = require("dim.diagnostic_util")
+
 -- UTIL FUNCTIONS END
 --- Highlight unused vars and functions
 dim.hig_unused = function()
@@ -129,8 +131,7 @@ dim.hig_unused = function()
   if ok then
     vim.api.nvim_buf_clear_namespace(0, dim.ns, 0, -1)
     for _, lsp_datum in ipairs(lsp_data) do
-      local message = string.lower((lsp_datum.user_data and lsp_datum.user_data.lsp.code) or lsp_datum.message or "")
-      if string.match(message, "never read") or string.match(message, "unused") then
+      if diagnostic_util.is_unused_symbol_diagnostic(lsp_datum) then
         util.highlight_word(dim.ns, lsp_datum.lnum, lsp_datum.col, lsp_datum.end_col)
       end
     end

--- a/lua/dim/diagnostic_util.lua
+++ b/lua/dim/diagnostic_util.lua
@@ -1,8 +1,9 @@
 local M = {}
 
+---@param lsp_datum Diagnostic
 local function get_message_from_lsp_diagnostic(lsp_datum)
-  if lsp_datum.user_data and lsp_datum.user_data.lsp.code and type(lsp_datum.user_data.lsp.code) == "string" then
-    return lsp_datum.user_data.lsp.code
+  if lsp_datum.code and type(lsp_datum.code) == "string" then
+    return lsp_datum.code
   end
 
   return lsp_datum.message or ""

--- a/lua/dim/diagnostic_util.lua
+++ b/lua/dim/diagnostic_util.lua
@@ -1,7 +1,11 @@
 local M = {}
 
 local function get_message_from_lsp_diagnostic(lsp_datum)
-  return (lsp_datum.user_data and lsp_datum.user_data.lsp.code) or lsp_datum.message or ""
+  if lsp_datum.user_data and lsp_datum.user_data.lsp.code and type(lsp_datum.user_data.lsp.code) == "string" then
+    return lsp_datum.user_data.lsp.code
+  end
+
+  return lsp_datum.message or ""
 end
 
 function M.is_unused_symbol_diagnostic(lsp_datum)

--- a/lua/dim/diagnostic_util.lua
+++ b/lua/dim/diagnostic_util.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+local function get_message_from_lsp_diagnostic(lsp_datum)
+  return (lsp_datum.user_data and lsp_datum.user_data.lsp.code) or lsp_datum.message or ""
+end
+
+function M.is_unused_symbol_diagnostic(lsp_datum)
+  local message = string.lower(get_message_from_lsp_diagnostic(lsp_datum))
+  return string.match(message, "never read") or string.match(message, "unused")
+end
+
+return M

--- a/tests/diagnostic_util_spec.lua
+++ b/tests/diagnostic_util_spec.lua
@@ -1,0 +1,61 @@
+describe("is_unused_symbol_diagnostic", function()
+  local test_cases = {
+    {
+      description = "detects unused symbols from lua diagnostics",
+      lsp_datum = {
+        bufnr = 1,
+        code = "unused-local",
+        col = 53,
+        end_col = 56,
+        end_lnum = 124,
+        lnum = 124,
+        message = "Unused local `abc`.",
+        namespace = 47,
+        severity = 4,
+        source = "Lua Diagnostics.",
+        user_data = {
+          lsp = {
+            code = "unused-local",
+            tags = { 1 },
+          },
+        },
+      },
+      expected_result = true,
+    },
+    {
+      description = "detects unused symbols from tsserver diagnostics",
+      lsp_datum = {
+        bufnr = 41,
+        code = 6133,
+        col = 6,
+        end_col = 20,
+        end_lnum = 1,
+        lnum = 1,
+        message = "'someVariable' is declared but its value is never read.",
+        namespace = 54,
+        severity = 4,
+        source = "typescript",
+        user_data = {
+          lsp = {
+            code = 6133,
+            tags = { 1 },
+          },
+        },
+      },
+      expected_result = true,
+    },
+  }
+
+  local diagnostic_util = require("dim.diagnostic_util")
+
+  for _, test_case in ipairs(test_cases) do
+    it(test_case.description, function()
+      local result = diagnostic_util.is_unused_symbol_diagnostic(test_case.lsp_datum)
+      if test_case.expected_result then
+        assert.truthy(result)
+      else
+        assert.falsy(result)
+      end
+    end)
+  end
+end)

--- a/tests/unused.ts
+++ b/tests/unused.ts
@@ -1,0 +1,4 @@
+// Should be dimmed
+const unusedVariable = true;
+
+export const usedVariable = true;


### PR DESCRIPTION
I took a stab at fixing `tsserver` support. I noticed that in `tsserver` diagnostics, the `lsp.code` is a number. The plugin previously used that number when matching against `unused` and `never used` strings, which never matched. I modified the logic to use `lsp.code` only if it is a `string`.

I also added some unit tests using [Plenary](https://github.com/nvim-lua/plenary.nvim#plenarytest_harness) to detect regressions easier. This is a non-breaking change. It does not require users of this plugin to install Plenary. It is only required to run the tests.

Closes #9  