### PR TITLE
Support for Java jdtls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dim
+
 **dim** is a lua plugin for neovim to dim the unused variables and functions using lsp and treesitter.
 
 <video src = "https://user-images.githubusercontent.com/79555780/157270883-da3120c8-b8b2-4036-8063-3b5ce10d4d88.mp4"></video>
@@ -50,8 +51,10 @@ Dim comes with the following defaults:
 ```
 
 ## Tested LSPs
+
 | LSPs          | Status |
-|---------------|--------|
-| tsserver      | ✔️      | 
-| sumneko_lua   | ✔️      | 
-| rust_analyzer | ✔️      | 
+| ------------- | ------ |
+| tsserver      | ✔️     |
+| sumneko_lua   | ✔️     |
+| rust_analyzer | ✔️     |
+| jdtls         | ✔️     |

--- a/lua/dim/diagnostic_util.lua
+++ b/lua/dim/diagnostic_util.lua
@@ -1,3 +1,5 @@
+local matchers = require("dim.matchers")
+
 local M = {}
 
 ---@param lsp_datum Diagnostic
@@ -11,7 +13,12 @@ end
 
 function M.is_unused_symbol_diagnostic(lsp_datum)
   local message = string.lower(get_message_from_lsp_diagnostic(lsp_datum))
-  return string.match(message, "never read") or string.match(message, "unused")
+  for _, matcher in ipairs(matchers) do
+    if string.match(message, matcher) then
+      return true
+    end
+  end
+  return false
 end
 
 return M

--- a/lua/dim/matchers.lua
+++ b/lua/dim/matchers.lua
@@ -3,4 +3,5 @@ return {
   "unused", -- sumneko_lua rust_analyzer
   "536870973", -- jdtls variables
   "603979894", -- jdtls private methods
+  "570425421", -- jdtls private fields
 }

--- a/lua/dim/matchers.lua
+++ b/lua/dim/matchers.lua
@@ -1,0 +1,6 @@
+return {
+  "never read", -- tsserver
+  "unused", -- sumneko_lua rust_analyzer
+  "536870973", -- jdtls variables
+  "603979894", -- jdtls private methods
+}

--- a/tests/diagnostic_util_spec.lua
+++ b/tests/diagnostic_util_spec.lua
@@ -51,6 +51,13 @@ describe("is_unused_symbol_diagnostic", function()
       },
       expected_result = true,
     },
+    {
+      description = "detects unused private methods from jdtls diagnostics",
+      lsp_datum = {
+        code = "603979894",
+      },
+      expected_result = true,
+    },
   }
 
   local diagnostic_util = require("dim.diagnostic_util")

--- a/tests/diagnostic_util_spec.lua
+++ b/tests/diagnostic_util_spec.lua
@@ -44,6 +44,13 @@ describe("is_unused_symbol_diagnostic", function()
       },
       expected_result = true,
     },
+    {
+      description = "detects unused symbols from jdtls diagnostics",
+      lsp_datum = {
+        code = "536870973",
+      },
+      expected_result = true,
+    },
   }
 
   local diagnostic_util = require("dim.diagnostic_util")

--- a/tests/unused.java
+++ b/tests/unused.java
@@ -1,0 +1,13 @@
+package tests;
+
+/** unused */
+class Unused {
+
+    private String unusedField = "dsadsa";
+
+    private void unusedMethod() {}
+
+    public static void main() {
+        String unusedVariable = "dsadasdas";
+    }
+}


### PR DESCRIPTION
Hello there - great plugin.

This pr adds support for Java jdtls both private methods, private fields and variables.

I've also moved the strings used to match on into a separate file making it easier for others to add new ones in the future.

Image of it working using the tests/unused.java file i added:
![java-unused](https://user-images.githubusercontent.com/70150300/181368866-fd0ee9e9-9a79-4d93-8dd8-f96aaf20ba85.png)