### PR TITLE
Use global namespace to define highlights (fixes plugin after recent Neovim `hl_ns` breaking change)

### DIFF
--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -38,7 +38,7 @@ function util.darken(hex, amount, bg)
   return util.blend(hex, bg or "#000000", math.abs(amount))
 end
 
-function util.highlight_word(ns, line, from, to)
+function util.highlight_word(line, from, to)
   -- null ls
   if from == to and to == 0 then
     from = 0
@@ -55,11 +55,11 @@ function util.highlight_word(ns, line, from, to)
     color = "#ffffff"
   end
   vim.api.nvim_set_hl(
-    dim.ns,
+    0,
     string.format("%sDimmed", final),
     { fg = util.darken(color, 0.75), undercurl = false, underline = false }
   )
-  vim.api.nvim_buf_add_highlight(0, ns, string.format("%sDimmed", final), line, from, to)
+  vim.api.nvim_buf_add_highlight(0, dim.ns, string.format("%sDimmed", final), line, from, to)
   if dim.opts.disable_lsp_decorations then
     for _, lsp_ns in pairs(vim.diagnostic.get_namespaces()) do
       local namespaces_to_clear = { "underline_ns", "virt_text_ns", "sign_group" }
@@ -132,7 +132,7 @@ dim.hig_unused = function()
     vim.api.nvim_buf_clear_namespace(0, dim.ns, 0, -1)
     for _, lsp_datum in ipairs(lsp_data) do
       if diagnostic_util.is_unused_symbol_diagnostic(lsp_datum) then
-        util.highlight_word(dim.ns, lsp_datum.lnum, lsp_datum.col, lsp_datum.end_col)
+        util.highlight_word(lsp_datum.lnum, lsp_datum.col, lsp_datum.end_col)
       end
     end
   end
@@ -154,8 +154,6 @@ dim.setup = function(tbl)
     autocmd DiagnosticChanged * lua require("dim").hig_unused()
     augroup END
   ]])
-
-  vim.api.nvim__set_hl_ns(dim.ns)
 end
 
 return dim

--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -54,12 +54,9 @@ function util.highlight_word(line, from, to)
   if #color ~= 7 then
     color = "#ffffff"
   end
-  vim.api.nvim_set_hl(
-    0,
-    string.format("%sDimmed", final),
-    { fg = util.darken(color, 0.75), undercurl = false, underline = false }
-  )
-  vim.api.nvim_buf_add_highlight(0, dim.ns, string.format("%sDimmed", final), line, from, to)
+  local hl_group = string.format("%sDimmed", final)
+  vim.api.nvim_set_hl(0, hl_group, { fg = util.darken(color, 0.75), undercurl = false, underline = false })
+  vim.api.nvim_buf_add_highlight(0, dim.ns, hl_group, line, from, to)
   if dim.opts.disable_lsp_decorations then
     for _, lsp_ns in pairs(vim.diagnostic.get_namespaces()) do
       local namespaces_to_clear = { "underline_ns", "virt_text_ns", "sign_group" }


### PR DESCRIPTION
Do not change Neovim's current highlight namespace to `dim.ns`. That required setting the highlight groups in the `dim.ns` namespace. Aside from [the recent breaking change in Neovim's API for setting the `hl_ns`](https://github.com/neovim/neovim/commit/35653e6bcda6923b5213fb9356c35067d6d0288f), this means that this plugin expects no other plugin to manage the Neovim's highlight namespace. The dim.lua plugin is not a highlight manager, so IMO it should not set the Neovim highlight namespace.

Instead, the dim.lua highlight groups (e.g. `TSVariableDimmed` or `TSParameterDimmed`) are defined in the **global** highlight namespace. However, lines are highlighted using the `dim.ns` namespace. This makes it so that `nvim_buf_clear_namespace` clears only the highlighted text in the `dim.ns` namespace.

All in all, this change makes it so that the plugin does not assume anything about the current Neovim highlight namespace and lets other plugins set it, and it still works regardless, because it sets the highlight groups in the global namespace.

Fixes https://github.com/NarutoXY/dim.lua/issues/15

Update from 2022-08-28: [another Neovim breaking change](https://github.com/neovim/neovim/issues/14090#issuecomment-1228444035) causes this PR to be not enough to work on Neovim nightly. This PR needs to be followed up by #17 for this plugin to work on nightly again.

## Verification

TypeScript:

![image](https://user-images.githubusercontent.com/889383/185738587-83a05da5-8e61-42ce-96a9-d313b56342e7.png)


Java:

![image](https://user-images.githubusercontent.com/889383/185738561-83cf1e38-8301-4516-94a4-c0dd88d23adc.png)

Lua:

![image](https://user-images.githubusercontent.com/889383/185738574-4937290b-b839-4696-b576-6a8e4472717c.png)

I don't have any Python LS installed so I can't check it.