### PR TITLE
fix: use higher-level API to get capture names

### DIFF
--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -38,7 +38,7 @@ function util.darken(hex, amount, bg)
   return util.blend(hex, bg or "#000000", math.abs(amount))
 end
 
-function util.highlight_word(ns, line, from, to)
+function util.highlight_word(line, from, to)
   -- null ls
   if from == to and to == 0 then
     from = 0
@@ -55,11 +55,11 @@ function util.highlight_word(ns, line, from, to)
     color = "#ffffff"
   end
   vim.api.nvim_set_hl(
-    dim.ns,
+    0,
     string.format("%sDimmed", final),
     { fg = util.darken(color, 0.75), undercurl = false, underline = false }
   )
-  vim.api.nvim_buf_add_highlight(0, ns, string.format("%sDimmed", final), line, from, to)
+  vim.api.nvim_buf_add_highlight(0, dim.ns, string.format("%sDimmed", final), line, from, to)
   if dim.opts.disable_lsp_decorations then
     for _, lsp_ns in pairs(vim.diagnostic.get_namespaces()) do
       local namespaces_to_clear = { "underline_ns", "virt_text_ns", "sign_group" }
@@ -132,7 +132,7 @@ dim.hig_unused = function()
     vim.api.nvim_buf_clear_namespace(0, dim.ns, 0, -1)
     for _, lsp_datum in ipairs(lsp_data) do
       if diagnostic_util.is_unused_symbol_diagnostic(lsp_datum) then
-        util.highlight_word(dim.ns, lsp_datum.lnum, lsp_datum.col, lsp_datum.end_col)
+        util.highlight_word(lsp_datum.lnum, lsp_datum.col, lsp_datum.end_col)
       end
     end
   end
@@ -154,8 +154,6 @@ dim.setup = function(tbl)
     autocmd DiagnosticChanged * lua require("dim").hig_unused()
     augroup END
   ]])
-
-  vim.api.nvim__set_hl_ns(dim.ns)
 end
 
 return dim

--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -77,6 +77,14 @@ end
 function util.get_treesitter_hl(row, col)
   local buf = vim.api.nvim_get_current_buf()
 
+  -- NOTE: use new functionality from https://github.com/neovim/neovim/issues/14090#issuecomment-1228444035
+  if vim.treesitter.get_captures_at_position ~= nil then
+    local matches = vim.treesitter.get_captures_at_position(buf, row, col)
+    return vim.tbl_map(function(match)
+      return "@" .. match.capture
+    end, matches)
+  end
+
   local self = highlighter.active[buf]
   if not self then
     return {}

--- a/lua/dim.lua
+++ b/lua/dim.lua
@@ -54,12 +54,9 @@ function util.highlight_word(line, from, to)
   if #color ~= 7 then
     color = "#ffffff"
   end
-  vim.api.nvim_set_hl(
-    0,
-    string.format("%sDimmed", final),
-    { fg = util.darken(color, 0.75), undercurl = false, underline = false }
-  )
-  vim.api.nvim_buf_add_highlight(0, dim.ns, string.format("%sDimmed", final), line, from, to)
+  local hl_group = string.format("%sDimmed", final)
+  vim.api.nvim_set_hl(0, hl_group, { fg = util.darken(color, 0.75), undercurl = false, underline = false })
+  vim.api.nvim_buf_add_highlight(0, dim.ns, hl_group, line, from, to)
   if dim.opts.disable_lsp_decorations then
     for _, lsp_ns in pairs(vim.diagnostic.get_namespaces()) do
       local namespaces_to_clear = { "underline_ns", "virt_text_ns", "sign_group" }


### PR DESCRIPTION
[The recent breaking change of capture-based Treesitter highlight groups](https://github.com/neovim/neovim/issues/14090#issuecomment-1228444035) removed the `_get_hl_from_capture` method available on `TSHighlighterQuery`. `get_captures_at_position` should be used instead. The highlight group name is the capture name prefixed by the `@` symbol.

This fixes the plugin on Neovim nightly while preserving old functionality on older versions when `get_captures_at_position` is not available.

## Merge order

This PR should consist of only a single commit, but it requires #16 to be merged first.

Right now it says the PR contains 3 commits because it also contains the commits from #16. I could not create the PR targeting the branch used in #16 because it would not appear in the upstream repo (https://github.com/NarutoXY/dim.lua), but in my fork (https://github.com/Gelio/dim.lua).

## Verification

The TS, Java, and Lua tests work:

![image](https://user-images.githubusercontent.com/889383/187066570-7a74c39d-5297-48c8-9a53-3579e12dd910.png)

![image](https://user-images.githubusercontent.com/889383/187066574-22de3969-672a-4743-ae5d-becb9eccc693.png)

![image](https://user-images.githubusercontent.com/889383/187066583-ba22dc04-79a5-44e4-a8ca-442fe6733c0f.png)

I don't have Python LSP installed so I can't test it.